### PR TITLE
Use correct command termination for compatibility

### DIFF
--- a/source/mail/smtp.d
+++ b/source/mail/smtp.d
@@ -219,7 +219,7 @@ private:
 	{
 		if (!_sock.isOpen)
 			return SmtpReply(false);
-		_sock.send(command ~ "\n");
+		_sock.send(command ~ "\r\n");
 		return parseReply(receiveAll);
 	}
 


### PR DESCRIPTION
The lack of the \r was causing incompatibility with authentication on gmail smtp servers.
