### PR TITLE
Fix compile error with Win64

### DIFF
--- a/source/mail/socket.d
+++ b/source/mail/socket.d
@@ -131,8 +131,10 @@ public:
 		if (_ssl is null)
 			return false;
 
-
-		SSL_set_fd(_ssl, _sock.handle);
+		version(Win64)
+				SSL_set_fd(_ssl, cast(int)_sock.handle);
+		else
+				SSL_set_fd(_ssl, _sock.handle);
 
 		// Handshake
 		if (SSL_connect(_ssl) != 1)


### PR DESCRIPTION
A Windows SOCKET is a pointer. OpenSSL's SSL_set_fd() expects a file
handle of 32bit. Because the high bits are always zero the required
cast is safe.

See http://stackoverflow.com/questions/1953639/is-it-safe-to-cast-socket-to-int-under-win64.
