### PR TITLE
pop3: added methods for getting just the headers (TOP) and UIDLs

### DIFF
--- a/source/mail/msg.d
+++ b/source/mail/msg.d
@@ -97,6 +97,7 @@ struct Msg
 		auto ct   = m.headers.all("content-type").length ? m.headers["content-type"] : ""; 
 		auto enc  = m.headers.all("content-transfer-encoding").length ? m.headers["content-transfer-encoding"].toLower : "";
 
+		if ((cast(string)data).strip.empty) return m;
 		//	Transfer encoding
 		switch(enc)
 		{


### PR DESCRIPTION
Pop3.getHeaders(id) method allows retrieving just the headers of a message, without the body.

Pop3.getUIDLs() method returns a list of pairs (id, unique_id_string) for all the messages in the mailbox. These can be used to track which messages we've seen earlier.

Also fixed multiline answer parsing (status and data are separated by line break there, not just space).